### PR TITLE
ExternsDiff: compute deps of TypeSynonyms properly

### DIFF
--- a/src/Language/PureScript/Make/ExternsDiff.hs
+++ b/src/Language/PureScript/Make/ExternsDiff.hs
@@ -411,11 +411,6 @@ externsTypeFixityToRef (P.ExternsTypeFixity _ _ n alias) =
 externsDeclarationToRef :: ModuleName -> P.ExternsDeclaration -> Maybe RefWithDeps
 externsDeclarationToRef moduleName = \case
   P.EDType n t tk
-    | P.TypeSynonym <- tk ->
-        -- Type synonyms have two entries in externs: EDType and EDTypeSynonym. 
-        -- Ignore the EDType entry, because later in the code we can't handle duplicate entries with the same Ref.
-        -- (TODO: is this legit? Will EDTypeSynonym contain all the deps of edTypeKind?)
-        Nothing
     | P.isDictTypeName n -> Nothing
     | otherwise -> Just (TypeRef n, typeDeps t <> typeKindDeps tk)
   --

--- a/src/Language/PureScript/Make/ExternsDiff.hs
+++ b/src/Language/PureScript/Make/ExternsDiff.hs
@@ -411,6 +411,11 @@ externsTypeFixityToRef (P.ExternsTypeFixity _ _ n alias) =
 externsDeclarationToRef :: ModuleName -> P.ExternsDeclaration -> Maybe RefWithDeps
 externsDeclarationToRef moduleName = \case
   P.EDType n t tk
+    | P.TypeSynonym <- tk ->
+        -- Type synonyms have two entries in externs: EDType and EDTypeSynonym. 
+        -- Ignore the EDType entry, because later in the code we can't handle duplicate entries with the same Ref.
+        -- (TODO: is this legit? Will EDTypeSynonym contain all the deps of edTypeKind?)
+        Nothing
     | P.isDictTypeName n -> Nothing
     | otherwise -> Just (TypeRef n, typeDeps t <> typeKindDeps tk)
   --


### PR DESCRIPTION
Fixes a bug where type synonym changes are incorrectly computed when diffing externs.

See https://github.com/zyla/purs-recompilation-repro for a reproducer of the bug.

Bug explanation: Externs files can have multiple entries with the same `Ref`, but the code in `ExternsDiff` assumed uniqueness. This led to buggy dependency graph construction.

The fix is to merge duplicate entries.