### PR TITLE
ExternsDiff: Consider all types recursively in instance head as dependencies

### DIFF
--- a/src/Language/PureScript/Make/ExternsDiff.hs
+++ b/src/Language/PureScript/Make/ExternsDiff.hs
@@ -445,7 +445,7 @@ externsDeclarationToRef moduleName = \case
   --
   P.EDInstance cn n args kinds types constraints _ _ _ _ ->
     Just
-      ( TypeInstanceRef n (qualified cn) (mapMaybe myType types)
+      ( TypeInstanceRef n (qualified cn) (foldMap (P.everythingOnTypes (<>) (maybeToList . myType)) types)
       , maybe mempty constraintsDeps constraints <> instanceArgsDeps args <> foldMap typeDeps kinds
       )
   where


### PR DESCRIPTION
Fixes recompilation bug reproduced by https://github.com/zyla/purs-recompilation-repro-2.

The bug happens in converting an EDInstance to a Ref. `TypeInstanceRef` contains a list of local types mentioned in the instance head. However, the conversion only detected types mentioned directly in the instance head without arguments.

So in the reproduction example, we get the following entry in `depsDiffs`:

`ProperName {runProperName = "Bar"}),Updated),(TypeInstanceRef (Ident "fooBar") (ModuleName "TC",ProperName {runProperName = "Foo"}) []`

When we should get:

`ProperName {runProperName = "Bar"}),Updated),(TypeInstanceRef (Ident "fooBar") (ModuleName "TC",ProperName {runProperName = "Foo"}) [ProperName {runProperName = "Bar"}]`

The fix is to recursively traverse the instance head, searching for local types.