### PR TITLE
type-hash: HashSet for unificationCache (-15.4% full build on pr-admin)

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -168,7 +168,7 @@ common defaults
     clock >=0.8.3 && <0.9,
     containers >=0.6.5.1 && <0.7,
     -- unordered-containers,
-    -- hashable,
+    hashable >=1.4.2.0 && <1.5,
     cryptonite ==0.30.*,
     data-ordlist >=0.4.7.0 && <0.5,
     deepseq >=1.4.6.1 && <1.5,

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -167,7 +167,7 @@ common defaults
     cheapskate >=0.1.1.2 && <0.2,
     clock >=0.8.3 && <0.9,
     containers >=0.6.5.1 && <0.7,
-    -- unordered-containers,
+    unordered-containers >=0.2.19.1 && <0.3,
     hashable >=1.4.2.0 && <1.5,
     cryptonite ==0.30.*,
     data-ordlist >=0.4.7.0 && <0.5,

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -9,6 +9,7 @@ import Prelude
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)
 import Data.Aeson ((.=), (.:))
+import Data.Hashable (Hashable)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Language.PureScript.Comments (Comment)
@@ -26,6 +27,8 @@ data SourcePos = SourcePos
   , sourcePosColumn :: Int
     -- ^ Column number
   } deriving (Show, Eq, Ord, Generic, NFData, Serialise)
+
+instance Hashable SourcePos
 
 displaySourcePos :: SourcePos -> Text
 displaySourcePos sp =

--- a/src/Language/PureScript/Label.hs
+++ b/src/Language/PureScript/Label.hs
@@ -4,6 +4,7 @@ import Prelude
 import GHC.Generics (Generic)
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)
+import Data.Hashable (Hashable(..))
 import Data.Monoid ()
 import Data.String (IsString(..))
 import Data.Aeson qualified as A
@@ -19,3 +20,5 @@ newtype Label = Label { runLabel :: PSString }
 
 instance NFData Label
 instance Serialise Label
+instance Hashable Label where
+  hashWithSalt s (Label p) = hashWithSalt s p

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -12,6 +12,7 @@ import Control.Applicative ((<|>))
 import Control.Monad.Supply.Class (MonadSupply(..))
 import Control.DeepSeq (NFData)
 import Data.Functor.Contravariant (contramap)
+import Data.Hashable (Hashable(..))
 import Data.Vector qualified as V
 
 import GHC.Generics (Generic)
@@ -36,6 +37,7 @@ data Name
 
 instance NFData Name
 instance Serialise Name
+instance Hashable Name
 
 getIdentName :: Name -> Maybe Ident
 getIdentName (IdentName name) = Just name
@@ -75,6 +77,7 @@ data InternalIdentData
 
 instance NFData InternalIdentData
 instance Serialise InternalIdentData
+instance Hashable InternalIdentData
 
 -- |
 -- Names for value identifiers
@@ -100,6 +103,7 @@ data Ident
 
 instance NFData Ident
 instance Serialise Ident
+instance Hashable Ident
 
 unusedIdent :: Text
 unusedIdent = "$__unused"
@@ -132,6 +136,8 @@ newtype OpName (a :: OpNameType) = OpName { runOpName :: Text }
 
 instance NFData (OpName a)
 instance Serialise (OpName a)
+instance Hashable (OpName a) where
+  hashWithSalt s (OpName t) = hashWithSalt s t
 
 instance ToJSON (OpName a) where
   toJSON = toJSON . runOpName
@@ -161,6 +167,8 @@ newtype ProperName (a :: ProperNameType) = ProperName { runProperName :: Text }
 
 instance NFData (ProperName a)
 instance Serialise (ProperName a)
+instance Hashable (ProperName a) where
+  hashWithSalt s (ProperName t) = hashWithSalt s t
 
 instance ToJSON (ProperName a) where
   toJSON = toJSON . runProperName
@@ -193,6 +201,8 @@ newtype ModuleName = ModuleName Text
   deriving newtype Serialise
 
 instance NFData ModuleName
+instance Hashable ModuleName where
+  hashWithSalt s (ModuleName t) = hashWithSalt s t
 
 runModuleName :: ModuleName -> Text
 runModuleName (ModuleName name) = name
@@ -213,6 +223,7 @@ pattern ByNullSourcePos = BySourcePos (SourcePos 0 0)
 
 instance NFData QualifiedBy
 instance Serialise QualifiedBy
+instance Hashable QualifiedBy
 
 isBySourcePos :: QualifiedBy -> Bool
 isBySourcePos (BySourcePos _) = True
@@ -234,6 +245,7 @@ data Qualified a = Qualified QualifiedBy a
 
 instance NFData a => NFData (Qualified a)
 instance Serialise a => Serialise (Qualified a)
+instance Hashable a => Hashable (Qualified a)
 
 showQualified :: (a -> Text) -> Qualified a -> Text
 showQualified f (Qualified (BySourcePos  _) a) = f a

--- a/src/Language/PureScript/PSString.hs
+++ b/src/Language/PureScript/PSString.hs
@@ -18,6 +18,7 @@ import Control.Applicative ((<|>))
 import Data.Char qualified as Char
 import Data.Bits (shiftR)
 import Data.Either (fromRight)
+import Data.Hashable (Hashable(..))
 import Data.List (unfoldr)
 import Data.Scientific (toBoundedInteger)
 import Data.String (IsString(..))
@@ -53,6 +54,8 @@ newtype PSString = PSString { toUTF16CodeUnits :: [Word16] }
 
 instance NFData PSString
 instance Serialise PSString
+instance Hashable PSString where
+  hashWithSalt s (PSString ws) = hashWithSalt s ws
 
 instance Show PSString where
   show = show . codePoints

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -14,6 +14,7 @@ import Control.Monad.State.Strict qualified as StrictState
 
 import Data.Maybe (fromMaybe)
 import Data.IntMap.Lazy qualified as IM
+import Data.HashSet qualified as HS
 import Data.Map qualified as M
 import Data.Set qualified as S
 import Data.Text (Text, isPrefixOf, unpack)
@@ -133,7 +134,7 @@ data CheckState = CheckState
   , checkConstructorImportsForCoercible :: S.Set (ModuleName, Qualified (ProperName 'ConstructorName))
   -- ^ Newtype constructors imports required to solve Coercible constraints.
   -- We have to keep track of them so that we don't emit unused import warnings.
-  , unificationCache :: S.Set (SourceType, SourceType)
+  , unificationCache :: HS.HashSet (SourceType, SourceType)
   }
 
 -- | Create an empty @CheckState@

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -22,9 +22,11 @@ import Language.PureScript.Names (ProperName, ProperNameType(..), Qualified)
 import Language.PureScript.TypeChecker.Monad (getEnv, TypeCheckM)
 import Language.PureScript.Types
   ( SourceType, Type(..), TypeFlags
-  , combineFlags, completeBinderList, constraintNodeFlags, everythingOnTypes, forAllNodeFlags
-  , getAnnForType, hasFlag, overConstraintArgsAll, replaceAllTypeVars
-  , setFlag, skolemNodeFlags, tfSynonymsFree, typeFlags
+  , binaryNodeFlags, completeBinderList, constraintNodeFlags, ctorSalt_BinaryNoParensType, ctorSalt_KindApp, ctorSalt_KindedType, ctorSalt_TypeApp
+  , everythingOnTypes, forAllNodeFlags
+  , getAnnForType, hasFlag, overConstraintArgsAll, rconsNodeFlags, replaceAllTypeVars
+  , setFlag, skolemNodeFlags, ternaryNodeFlags, tfSynonymsFree, typeFlags
+  , unaryNodeFlags, ctorSalt_ParensInType
   )
 
 -- | Type synonym information (arguments with kinds, aliased type), indexed by name
@@ -106,31 +108,31 @@ replaceAllTypeSynonyms' syns kinds
   walkChildren :: SourceType -> Either MultipleErrors SourceType
   walkChildren (TypeApp_ _ ann t1 t2) = do
     t1' <- walk t1; t2' <- walk t2
-    return $! TypeApp_ (sf (typeFlags t1' `combineFlags` typeFlags t2')) ann t1' t2'
+    return $! TypeApp_ (sf (binaryNodeFlags ctorSalt_TypeApp t1' t2')) ann t1' t2'
   walkChildren (KindApp_ _ ann t1 t2) = do
     t1' <- walk t1; t2' <- walk t2
-    return $! KindApp_ (sf (typeFlags t1' `combineFlags` typeFlags t2')) ann t1' t2'
+    return $! KindApp_ (sf (binaryNodeFlags ctorSalt_KindApp t1' t2')) ann t1' t2'
   walkChildren (ForAll_ _ ann vis ident mbK ty sco) = do
     mbK' <- traverse walk mbK; ty' <- walk ty
-    return $! ForAll_ (sf (forAllNodeFlags mbK' ty' sco)) ann vis ident mbK' ty' sco
+    return $! ForAll_ (sf (forAllNodeFlags vis ident mbK' ty' sco)) ann vis ident mbK' ty' sco
   walkChildren (ConstrainedType_ _ ann c ty) = do
     c' <- overConstraintArgsAll (mapM walk) c; ty' <- walk ty
     return $! ConstrainedType_ (sf (constraintNodeFlags c' ty')) ann c' ty'
   walkChildren (Skolem_ _ ann name mbK i sc) = do
     mbK' <- traverse walk mbK
-    return $! Skolem_ (sf (skolemNodeFlags mbK')) ann name mbK' i sc
+    return $! Skolem_ (sf (skolemNodeFlags name mbK' i sc)) ann name mbK' i sc
   walkChildren (RCons_ _ ann name ty rest) = do
     ty' <- walk ty; rest' <- walk rest
-    return $! RCons_ (sf (typeFlags ty' `combineFlags` typeFlags rest')) ann name ty' rest'
+    return $! RCons_ (sf (rconsNodeFlags name ty' rest')) ann name ty' rest'
   walkChildren (KindedType_ _ ann ty k) = do
     ty' <- walk ty; k' <- walk k
-    return $! KindedType_ (sf (typeFlags ty' `combineFlags` typeFlags k')) ann ty' k'
+    return $! KindedType_ (sf (binaryNodeFlags ctorSalt_KindedType ty' k')) ann ty' k'
   walkChildren (BinaryNoParensType_ _ ann t1 t2 t3) = do
     t1' <- walk t1; t2' <- walk t2; t3' <- walk t3
-    return $! BinaryNoParensType_ (sf (typeFlags t1' `combineFlags` typeFlags t2' `combineFlags` typeFlags t3')) ann t1' t2' t3'
+    return $! BinaryNoParensType_ (sf (ternaryNodeFlags ctorSalt_BinaryNoParensType t1' t2' t3')) ann t1' t2' t3'
   walkChildren (ParensInType_ _ ann t) = do
     t' <- walk t
-    return $! ParensInType_ (sf (typeFlags t')) ann t'
+    return $! ParensInType_ (sf (unaryNodeFlags ctorSalt_ParensInType t')) ann t'
   walkChildren other = return $! markSF other
 
   lookupKindArgs :: Qualified (ProperName 'TypeName) -> [Text]

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -22,11 +22,9 @@ import Language.PureScript.Names (ProperName, ProperNameType(..), Qualified)
 import Language.PureScript.TypeChecker.Monad (getEnv, TypeCheckM)
 import Language.PureScript.Types
   ( SourceType, Type(..), TypeFlags
-  , binaryNodeFlags, completeBinderList, constraintNodeFlags, ctorSalt_BinaryNoParensType, ctorSalt_KindApp, ctorSalt_KindedType, ctorSalt_TypeApp
-  , everythingOnTypes, forAllNodeFlags
-  , getAnnForType, hasFlag, overConstraintArgsAll, rconsNodeFlags, replaceAllTypeVars
-  , setFlag, skolemNodeFlags, ternaryNodeFlags, tfSynonymsFree, typeFlags
-  , unaryNodeFlags, ctorSalt_ParensInType
+  , completeBinderList, everythingOnTypes
+  , getAnnForType, hasFlag, modifyFlags, overConstraintArgsAll
+  , replaceAllTypeVars, setFlag, tfSynonymsFree, typeFlags
   )
 
 -- | Type synonym information (arguments with kinds, aliased type), indexed by name
@@ -52,34 +50,20 @@ replaceAllTypeSynonyms' syns kinds
   sf :: TypeFlags -> TypeFlags
   sf = setFlag tfSynonymsFree
 
-  -- Mark a single node as synonym-free (no recursion)
+  -- Mark a single node as synonym-free (no recursion). 'modifyFlags' is
+  -- INLINEd, so GHC fuses construction (via pattern synonym) + flag mutation
+  -- into a single allocation via case-of-known-constructor.
   markSF :: SourceType -> SourceType
-  markSF (TUnknown_ f a b) = TUnknown_ (sf f) a b
-  markSF (TypeVar_ f a b) = TypeVar_ (sf f) a b
-  markSF (TypeLevelString_ f a b) = TypeLevelString_ (sf f) a b
-  markSF (TypeLevelInt_ f a b) = TypeLevelInt_ (sf f) a b
-  markSF (TypeWildcard_ f a b) = TypeWildcard_ (sf f) a b
-  markSF (TypeConstructor_ f a b) = TypeConstructor_ (sf f) a b
-  markSF (TypeOp_ f a b) = TypeOp_ (sf f) a b
-  markSF (TypeApp_ f a t1 t2) = TypeApp_ (sf f) a t1 t2
-  markSF (KindApp_ f a t1 t2) = KindApp_ (sf f) a t1 t2
-  markSF (ForAll_ f a v i k t s) = ForAll_ (sf f) a v i k t s
-  markSF (ConstrainedType_ f a c t) = ConstrainedType_ (sf f) a c t
-  markSF (Skolem_ f a n k i s) = Skolem_ (sf f) a n k i s
-  markSF (REmpty_ f a) = REmpty_ (sf f) a
-  markSF (RCons_ f a l t r) = RCons_ (sf f) a l t r
-  markSF (KindedType_ f a t k) = KindedType_ (sf f) a t k
-  markSF (BinaryNoParensType_ f a t1 t2 t3) = BinaryNoParensType_ (sf f) a t1 t2 t3
-  markSF (ParensInType_ f a t) = ParensInType_ (sf f) a t
+  markSF = modifyFlags sf
 
   -- Main walk: try synonym expansion at potential application sites,
   -- then recurse into children. Sets tfSynonymsFree on all output nodes.
   walk :: SourceType -> Either MultipleErrors SourceType
   walk t | hasFlag tfSynonymsFree (typeFlags t) = Right t
-  walk t@(TypeApp_ _ _ _ _) = trySyn t >>= walkChildren
-  walk t@(KindApp_ _ _ _ _) = trySyn t >>= walkChildren
-  walk t@(TypeConstructor_ _ _ _) = trySyn t >>= \t' -> case t' of
-    TypeConstructor_ _ _ _ -> Right (markSF t')  -- leaf
+  walk t@(TypeApp _ _ _) = trySyn t >>= walkChildren
+  walk t@(KindApp _ _ _) = trySyn t >>= walkChildren
+  walk t@(TypeConstructor _ _) = trySyn t >>= \t' -> case t' of
+    TypeConstructor _ _ -> Right (markSF t')  -- leaf
     _ -> walkChildren t'  -- synonym expanded to non-leaf
   walk t = walkChildren t
 
@@ -103,36 +87,38 @@ replaceAllTypeSynonyms' syns kinds
   go ss c kargs args (KindApp _ f arg) = go ss c (arg : kargs) args f
   go _ _ _ _ _ = return Nothing
 
-  -- Walk children and reconstruct with recomputed structural flags + tfSynonymsFree.
-  -- Uses raw constructors to set flags in a single allocation.
+  -- Walk children and reconstruct via pattern synonyms (which compute flags)
+  -- + markSF (which sets the synonym-free bit). The pattern synonym builder
+  -- and modifyFlags are both INLINE; GHC fuses them via case-of-known-
+  -- constructor into a single allocation per node.
   walkChildren :: SourceType -> Either MultipleErrors SourceType
-  walkChildren (TypeApp_ _ ann t1 t2) = do
+  walkChildren (TypeApp ann t1 t2) = do
     t1' <- walk t1; t2' <- walk t2
-    return $! TypeApp_ (sf (binaryNodeFlags ctorSalt_TypeApp t1' t2')) ann t1' t2'
-  walkChildren (KindApp_ _ ann t1 t2) = do
+    return $! markSF (TypeApp ann t1' t2')
+  walkChildren (KindApp ann t1 t2) = do
     t1' <- walk t1; t2' <- walk t2
-    return $! KindApp_ (sf (binaryNodeFlags ctorSalt_KindApp t1' t2')) ann t1' t2'
-  walkChildren (ForAll_ _ ann vis ident mbK ty sco) = do
+    return $! markSF (KindApp ann t1' t2')
+  walkChildren (ForAll ann vis ident mbK ty sco) = do
     mbK' <- traverse walk mbK; ty' <- walk ty
-    return $! ForAll_ (sf (forAllNodeFlags vis ident mbK' ty' sco)) ann vis ident mbK' ty' sco
-  walkChildren (ConstrainedType_ _ ann c ty) = do
+    return $! markSF (ForAll ann vis ident mbK' ty' sco)
+  walkChildren (ConstrainedType ann c ty) = do
     c' <- overConstraintArgsAll (mapM walk) c; ty' <- walk ty
-    return $! ConstrainedType_ (sf (constraintNodeFlags c' ty')) ann c' ty'
-  walkChildren (Skolem_ _ ann name mbK i sc) = do
+    return $! markSF (ConstrainedType ann c' ty')
+  walkChildren (Skolem ann name mbK i sc) = do
     mbK' <- traverse walk mbK
-    return $! Skolem_ (sf (skolemNodeFlags name mbK' i sc)) ann name mbK' i sc
-  walkChildren (RCons_ _ ann name ty rest) = do
+    return $! markSF (Skolem ann name mbK' i sc)
+  walkChildren (RCons ann name ty rest) = do
     ty' <- walk ty; rest' <- walk rest
-    return $! RCons_ (sf (rconsNodeFlags name ty' rest')) ann name ty' rest'
-  walkChildren (KindedType_ _ ann ty k) = do
+    return $! markSF (RCons ann name ty' rest')
+  walkChildren (KindedType ann ty k) = do
     ty' <- walk ty; k' <- walk k
-    return $! KindedType_ (sf (binaryNodeFlags ctorSalt_KindedType ty' k')) ann ty' k'
-  walkChildren (BinaryNoParensType_ _ ann t1 t2 t3) = do
+    return $! markSF (KindedType ann ty' k')
+  walkChildren (BinaryNoParensType ann t1 t2 t3) = do
     t1' <- walk t1; t2' <- walk t2; t3' <- walk t3
-    return $! BinaryNoParensType_ (sf (ternaryNodeFlags ctorSalt_BinaryNoParensType t1' t2' t3')) ann t1' t2' t3'
-  walkChildren (ParensInType_ _ ann t) = do
+    return $! markSF (BinaryNoParensType ann t1' t2' t3')
+  walkChildren (ParensInType ann t) = do
     t' <- walk t
-    return $! ParensInType_ (sf (unaryNodeFlags ctorSalt_ParensInType t')) ann t'
+    return $! markSF (ParensInType ann t')
   walkChildren other = return $! markSF other
 
   lookupKindArgs :: Qualified (ProperName 'TypeName) -> [Text]

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -34,7 +34,7 @@ import Language.PureScript.TypeChecker.Kinds (elaborateKind, instantiateKind, un
 import Language.PureScript.TypeChecker.Monad (CheckState(..), Substitution(..), UnkLevel(..), Unknown, getLocalContext, guardWith, lookupUnkName, withErrorMessageHint, TypeCheckM)
 import Language.PureScript.TypeChecker.Skolems (newSkolemConstant, skolemize)
 import Language.PureScript.Types (Constraint(..), pattern REmptyKinded, RowListItem(..), SourceType, Type(..), WildcardData(..), alignRowsWith, everythingOnTypes, everywhereOnTypes, everywhereOnTypesM, getAnnForType, hasFlag, mkForAll, rowFromList, srcTUnknown, tfHasWildcards, typeFlags)
-import Data.Set qualified as S
+import Data.HashSet qualified as HS
 
 -- | Generate a fresh type variable with an unknown kind. Avoid this if at all possible.
 freshType :: TypeCheckM SourceType
@@ -119,8 +119,8 @@ unifyTypes t1 t2 = do
   where
   unifyTypes'' t1' t2'= do
     cache <- gets unificationCache
-    when (S.notMember (t1', t2') cache) $ do
-      modify $ \st -> st { unificationCache = S.insert (t1', t2') cache }
+    when (not (HS.member (t1', t2') cache)) $ do
+      modify $ \st -> st { unificationCache = HS.insert (t1', t2') cache }
       unifyTypes' t1' t2'
   unifyTypes' (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()
   unifyTypes' (TUnknown _ u) t = solveType u t

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -2,8 +2,108 @@
 -- Data types for types
 --
 module Language.PureScript.Types
-  ( module Language.PureScript.Types
+  ( -- * Core types
+    SourceType
+  , SourceConstraint
+  , SkolemScope(..)
+  , WildcardData(..)
+  , TypeVarVisibility(..)
+  , TypeFlags(..)
+  , typeVarVisibilityPrefix
+    -- * Type AST
+    -- | The 'Type' data type's underlying constructors carry a 'TypeFlags'
+    -- field with a cached structural hash. Construction must go through
+    -- the bidirectional pattern synonyms (without the @_@ suffix) to ensure
+    -- the hash stays consistent. The underscore-suffixed constructors are
+    -- intentionally /not/ exported — use 'modifyFlags' to mutate flags
+    -- without invalidating the hash.
   , Type(TUnknown, TypeVar, TypeLevelString, TypeLevelInt, TypeWildcard, TypeConstructor, TypeOp, TypeApp, KindApp, ForAll, ConstrainedType, Skolem, REmpty, RCons, KindedType, BinaryNoParensType, ParensInType)
+  , pattern REmptyKinded
+  , Constraint(..)
+  , ConstraintData(..)
+  , RowListItem(..)
+    -- * Flag helpers
+  , tfHasWildcards
+  , tfHasUnscopedForAlls
+  , tfSynonymsFree
+  , hasFlag
+  , setFlag
+  , modifyFlags
+  , typeFlags
+    -- * Smart constructors
+  , srcTUnknown
+  , srcTypeVar
+  , srcTypeLevelString
+  , srcTypeLevelInt
+  , srcTypeWildcard
+  , srcTypeConstructor
+  , srcTypeApp
+  , srcKindApp
+  , srcForAll
+  , srcConstrainedType
+  , srcREmpty
+  , srcRCons
+  , srcKindedType
+  , srcConstraint
+  , srcInstanceType
+  , srcRowListItem
+    -- * JSON
+  , typeToJSON
+  , typeFromJSON
+  , typeVarVisToJSON
+  , typeVarVisFromJSON
+  , constraintToJSON
+  , constraintFromJSON
+  , constraintDataToJSON
+  , constraintDataFromJSON
+    -- * Equality / comparison
+  , eqType
+  , eqMaybeType
+  , compareType
+  , compareMaybeType
+  , eqConstraint
+  , compareConstraint
+    -- * Queries
+  , isMonoType
+  , isREmpty
+  , containsForAll
+  , containsUnknowns
+  , unknowns
+  , usedTypeVariables
+  , freeTypeVariables
+  , unapplyTypes
+  , unapplyConstraints
+  , annForType
+  , getAnnForType
+  , setAnnForType
+  , toREmptyKinded
+    -- * Traversals
+  , everythingOnTypes
+  , everythingWithContextOnTypes
+  , everywhereOnTypes
+  , everywhereOnTypesM
+  , everywhereOnTypesTopDownM
+    -- * Substitution / quantification
+  , replaceAllTypeVars
+  , replaceTypeVars
+  , mkForAll
+  , quantify
+  , addVisibility
+  , moveQuantifiersToFront
+  , completeBinderList
+  , genPureName
+  , eraseForAllKindAnnotations
+  , eraseKindApps
+    -- * Rows
+  , alignRowsWith
+  , rowFromList
+  , rowToList
+  , rowToSortedList
+    -- * Constraint helpers
+  , mapConstraintArgs
+  , mapConstraintArgsAll
+  , overConstraintArgs
+  , overConstraintArgsAll
   ) where
 
 import Prelude
@@ -90,11 +190,6 @@ data TypeFlags = TypeFlags { tfBits :: {-# UNPACK #-} !Word8, tfHash :: {-# UNPA
 instance NFData TypeFlags
 instance Serialise TypeFlags
 
--- | No flags set, zero hash. Used as the bit-only sentinel; real Type nodes
--- always have a non-zero hash via the pattern synonym builders.
-noFlags :: TypeFlags
-noFlags = TypeFlags 0 0
-
 -- | Subtree contains a 'TypeWildcard'.
 tfHasWildcards :: TypeFlags
 tfHasWildcards = TypeFlags 0x01 0
@@ -107,28 +202,9 @@ tfHasUnscopedForAlls = TypeFlags 0x02 0
 tfSynonymsFree :: TypeFlags
 tfSynonymsFree = TypeFlags 0x04 0
 
--- | Combine bit flags from child subtrees (only structural flags propagate).
--- The hash is /not/ combined here — pattern synonym builders compute the
--- node hash directly via 'innerNodeFlags' / 'leafNodeFlags', mixing in a
--- constructor-tag salt. Callers that already operate on combined bits
--- (e.g. 'forAllNodeFlags') don't go through this helper.
---
--- Why clear 'tfSynonymsFree'? Constructing a new type from synonym-free
--- children can still create a new synonym application at the parent, even
--- when both children are themselves synonym-free. Example:
---
--- @
---   Before substitution: TypeApp (TUnknown u) someArg    -- no synonyms
---   Substitution:        u -> TypeConstructor SomeAlias  -- standalone, fine
---   After substitution:  TypeApp (TypeConstructor SomeAlias) someArg
---                        -- now a fully-applied synonym that needs expansion!
--- @
-combineFlags :: TypeFlags -> TypeFlags -> TypeFlags
-combineFlags (TypeFlags a _) (TypeFlags b _) =
-  TypeFlags ((a .|. b) .&. structuralMask) 0
-
 -- | Mask of flags that propagate structurally from children to parents.
--- Processing flags (like 'tfSynonymsFree') are excluded — see 'combineFlags'.
+-- Processing flags (like 'tfSynonymsFree') are excluded — only flags
+-- describing structural properties of the subtree bubble up.
 structuralMask :: Word8
 structuralMask = w .|. w' where
   TypeFlags w  _ = tfHasWildcards
@@ -147,8 +223,7 @@ setFlag (TypeFlags f _) (TypeFlags w h) = TypeFlags (w .|. f) h
 -- Note: with the @UNPACK@ pragma on @TypeFlags@ in every 'Type' constructor,
 -- this function reconstructs a 'TypeFlags' value from the unpacked Word8 +
 -- Int fields, which means each call boxes if not inlined. Hot paths that
--- only need one of the two fields should use 'typeHash' or 'typeBits'
--- directly to avoid the box.
+-- only need the cached hash should use 'typeHash' directly to avoid the box.
 typeFlags :: Type a -> TypeFlags
 typeFlags (TUnknown_ f _ _) = f
 typeFlags (TypeVar_ f _ _) = f
@@ -192,31 +267,32 @@ typeHash (BinaryNoParensType_ (TypeFlags _ h) _ _ _ _) = h
 typeHash (ParensInType_ (TypeFlags _ h) _ _) = h
 {-# INLINE typeHash #-}
 
--- | Direct accessor for a Type's bit flags, avoiding TypeFlags boxing.
-typeBits :: Type a -> Word8
-typeBits (TUnknown_ (TypeFlags w _) _ _) = w
-typeBits (TypeVar_ (TypeFlags w _) _ _) = w
-typeBits (TypeLevelString_ (TypeFlags w _) _ _) = w
-typeBits (TypeLevelInt_ (TypeFlags w _) _ _) = w
-typeBits (TypeWildcard_ (TypeFlags w _) _ _) = w
-typeBits (TypeConstructor_ (TypeFlags w _) _ _) = w
-typeBits (TypeOp_ (TypeFlags w _) _ _) = w
-typeBits (TypeApp_ (TypeFlags w _) _ _ _) = w
-typeBits (KindApp_ (TypeFlags w _) _ _ _) = w
-typeBits (ForAll_ (TypeFlags w _) _ _ _ _ _ _) = w
-typeBits (ConstrainedType_ (TypeFlags w _) _ _ _) = w
-typeBits (Skolem_ (TypeFlags w _) _ _ _ _ _) = w
-typeBits (REmpty_ (TypeFlags w _) _) = w
-typeBits (RCons_ (TypeFlags w _) _ _ _ _) = w
-typeBits (KindedType_ (TypeFlags w _) _ _ _) = w
-typeBits (BinaryNoParensType_ (TypeFlags w _) _ _ _ _) = w
-typeBits (ParensInType_ (TypeFlags w _) _ _) = w
-{-# INLINE typeBits #-}
-
--- | Mask to extract only structural flags (clearing processing flags).
--- Preserves the hash.
-maskStructural :: TypeFlags -> TypeFlags
-maskStructural (TypeFlags w h) = TypeFlags (w .&. structuralMask) h
+-- | Apply a function to the flags of a Type node, preserving structure.
+-- Used by callers (e.g. 'replaceAllTypeSynonyms') that need to set a
+-- processing flag bit without recomputing the cached structural hash.
+-- Going through this helper is the only intended way to mutate flags
+-- from outside this module — the underscore-suffixed data constructors
+-- are not exported, so the cached hash cannot accidentally be invalidated.
+modifyFlags :: (TypeFlags -> TypeFlags) -> Type a -> Type a
+modifyFlags f = \case
+  TUnknown_ flags a x          -> TUnknown_ (f flags) a x
+  TypeVar_ flags a x           -> TypeVar_ (f flags) a x
+  TypeLevelString_ flags a x   -> TypeLevelString_ (f flags) a x
+  TypeLevelInt_ flags a x      -> TypeLevelInt_ (f flags) a x
+  TypeWildcard_ flags a x      -> TypeWildcard_ (f flags) a x
+  TypeConstructor_ flags a x   -> TypeConstructor_ (f flags) a x
+  TypeOp_ flags a x            -> TypeOp_ (f flags) a x
+  TypeApp_ flags a t1 t2       -> TypeApp_ (f flags) a t1 t2
+  KindApp_ flags a t1 t2       -> KindApp_ (f flags) a t1 t2
+  ForAll_ flags a v i k t s    -> ForAll_ (f flags) a v i k t s
+  ConstrainedType_ flags a c t -> ConstrainedType_ (f flags) a c t
+  Skolem_ flags a n k i s      -> Skolem_ (f flags) a n k i s
+  REmpty_ flags a              -> REmpty_ (f flags) a
+  RCons_ flags a l t r         -> RCons_ (f flags) a l t r
+  KindedType_ flags a t k      -> KindedType_ (f flags) a t k
+  BinaryNoParensType_ flags a t1 t2 t3 -> BinaryNoParensType_ (f flags) a t1 t2 t3
+  ParensInType_ flags a t      -> ParensInType_ (f flags) a t
+{-# INLINE modifyFlags #-}
 
 -- ---------------------------------------------------------------------------
 -- Hash mixing for the per-node structural hash
@@ -249,21 +325,10 @@ ctorSalt_KindedType          = 1093
 ctorSalt_BinaryNoParensType  = 1097
 ctorSalt_ParensInType        = 1103
 
--- | Mix two hashes via a multiply-add with the golden-ratio constant.
--- Same shape as 'Data.Hashable.combine' but inlined and Int-typed.
-mixHash :: Int -> Int -> Int
-mixHash a b = a * 0x9E3779B1 + b
-{-# INLINE mixHash #-}
-
 -- | Build TypeFlags for a leaf node, hashing one payload value.
 leafFlags1 :: Hashable x => Word8 -> Int -> x -> TypeFlags
 leafFlags1 bits salt x = TypeFlags bits (salt `hashWithSalt` x)
 {-# INLINE leafFlags1 #-}
-
--- | Build TypeFlags for a leaf node, hashing two payload values.
-leafFlags2 :: (Hashable x, Hashable y) => Word8 -> Int -> x -> y -> TypeFlags
-leafFlags2 bits salt x y = TypeFlags bits (salt `hashWithSalt` x `hashWithSalt` y)
-{-# INLINE leafFlags2 #-}
 
 -- | Compute hash of a 'Constraint' from its already-hashed children.
 constraintHash :: Constraint a -> Int
@@ -304,7 +369,7 @@ constraintNodeFlags c ty =
         (tfBits (typeFlags ty))
         (map typeFlags (constraintKindArgs c) ++ map typeFlags (constraintArgs c))
         .&. structuralMask
-    hash_ = mixHash (constraintHash c) (tfHash (typeFlags ty))
+    hash_ = constraintHash c `hashWithSalt` tfHash (typeFlags ty)
 {-# INLINE constraintNodeFlags #-}
 
 -- | Compute Skolem flags from its components.
@@ -326,7 +391,7 @@ binaryNodeFlags :: Int -> Type a -> Type a -> TypeFlags
 binaryNodeFlags salt t1 t2 =
     TypeFlags
       ((tfBits f1 .|. tfBits f2) .&. structuralMask)
-      (mixHash salt (mixHash (tfHash f1) (tfHash f2)))
+      (salt `hashWithSalt` tfHash f1 `hashWithSalt` tfHash f2)
   where
     f1 = typeFlags t1
     f2 = typeFlags t2
@@ -337,7 +402,7 @@ rconsNodeFlags :: Label -> Type a -> Type a -> TypeFlags
 rconsNodeFlags l ty rest =
     TypeFlags
       ((tfBits f1 .|. tfBits f2) .&. structuralMask)
-      (mixHash (mixHash (ctorSalt_RCons `hashWithSalt` l) (tfHash f1)) (tfHash f2))
+      (ctorSalt_RCons `hashWithSalt` l `hashWithSalt` tfHash f1 `hashWithSalt` tfHash f2)
   where
     f1 = typeFlags ty
     f2 = typeFlags rest
@@ -348,7 +413,7 @@ ternaryNodeFlags :: Int -> Type a -> Type a -> Type a -> TypeFlags
 ternaryNodeFlags salt t1 t2 t3 =
     TypeFlags
       ((tfBits f1 .|. tfBits f2 .|. tfBits f3) .&. structuralMask)
-      (mixHash salt (mixHash (tfHash f1) (mixHash (tfHash f2) (tfHash f3))))
+      (salt `hashWithSalt` tfHash f1 `hashWithSalt` tfHash f2 `hashWithSalt` tfHash f3)
   where
     f1 = typeFlags t1
     f2 = typeFlags t2
@@ -357,7 +422,7 @@ ternaryNodeFlags salt t1 t2 t3 =
 
 -- | Compute flags for a unary inner node (ParensInType).
 unaryNodeFlags :: Int -> Type a -> TypeFlags
-unaryNodeFlags salt t = TypeFlags (tfBits f .&. structuralMask) (mixHash salt (tfHash f))
+unaryNodeFlags salt t = TypeFlags (tfBits f .&. structuralMask) (salt `hashWithSalt` tfHash f)
   where f = typeFlags t
 {-# INLINE unaryNodeFlags #-}
 

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -20,6 +20,7 @@ import Data.Aeson qualified as A
 import Data.Aeson.Types qualified as A
 import Data.Bits ((.&.), (.|.))
 import Data.Foldable (fold, foldl')
+import Data.Hashable (Hashable(..))
 import Data.IntSet qualified as IS
 import Data.List (sortOn)
 import Data.Maybe (isJust)
@@ -45,6 +46,8 @@ newtype SkolemScope = SkolemScope { runSkolemScope :: Int }
 
 instance NFData SkolemScope
 instance Serialise SkolemScope
+instance Hashable SkolemScope where
+  hashWithSalt s (SkolemScope i) = hashWithSalt s i
 
 -- |
 -- Describes how a TypeWildcard should be presented to the user during
@@ -57,6 +60,7 @@ data WildcardData = HoleWildcard Text | UnnamedWildcard | IgnoredWildcard
 
 instance NFData WildcardData
 instance Serialise WildcardData
+instance Hashable WildcardData
 
 data TypeVarVisibility
   = TypeVarVisible
@@ -65,6 +69,7 @@ data TypeVarVisibility
 
 instance NFData TypeVarVisibility
 instance Serialise TypeVarVisibility
+instance Hashable TypeVarVisibility
 
 typeVarVisibilityPrefix :: TypeVarVisibility -> Text
 typeVarVisibilityPrefix = \case
@@ -75,34 +80,38 @@ typeVarVisibilityPrefix = \case
 -- Type flags: cached structural properties of a type subtree
 -- ---------------------------------------------------------------------------
 
--- | Cached information about what a type subtree contains. Stored per-node
--- so that traversals can short-circuit when a subtree is known to not
--- contain the nodes they are looking for.
-newtype TypeFlags = TypeFlags Word8
+-- | Cached information about what a type subtree contains, plus a structural
+-- hash. Stored per-node so that traversals can short-circuit when a subtree
+-- is known to not contain the nodes they are looking for, and so that
+-- 'eqType' / 'Hashable Type' run in O(1) up to a hash collision.
+data TypeFlags = TypeFlags { tfBits :: {-# UNPACK #-} !Word8, tfHash :: {-# UNPACK #-} !Int }
   deriving (Show, Eq, Ord, Generic)
 
 instance NFData TypeFlags
 instance Serialise TypeFlags
 
--- | No flags set.
+-- | No flags set, zero hash. Used as the bit-only sentinel; real Type nodes
+-- always have a non-zero hash via the pattern synonym builders.
 noFlags :: TypeFlags
-noFlags = TypeFlags 0
+noFlags = TypeFlags 0 0
 
 -- | Subtree contains a 'TypeWildcard'.
 tfHasWildcards :: TypeFlags
-tfHasWildcards = TypeFlags 0x01
+tfHasWildcards = TypeFlags 0x01 0
 
 -- | Subtree contains a 'ForAll' without a 'SkolemScope'.
 tfHasUnscopedForAlls :: TypeFlags
-tfHasUnscopedForAlls = TypeFlags 0x02
+tfHasUnscopedForAlls = TypeFlags 0x02 0
 
 -- | Subtree has been fully synonym-expanded by 'replaceAllTypeSynonyms'.
 tfSynonymsFree :: TypeFlags
-tfSynonymsFree = TypeFlags 0x04
+tfSynonymsFree = TypeFlags 0x04 0
 
--- | Combine flags from child subtrees. Only structural flags
--- ('tfHasWildcards', 'tfHasUnscopedForAlls') propagate; the processing flag
--- 'tfSynonymsFree' is always cleared.
+-- | Combine bit flags from child subtrees (only structural flags propagate).
+-- The hash is /not/ combined here — pattern synonym builders compute the
+-- node hash directly via 'innerNodeFlags' / 'leafNodeFlags', mixing in a
+-- constructor-tag salt. Callers that already operate on combined bits
+-- (e.g. 'forAllNodeFlags') don't go through this helper.
 --
 -- Why clear 'tfSynonymsFree'? Constructing a new type from synonym-free
 -- children can still create a new synonym application at the parent, even
@@ -114,31 +123,24 @@ tfSynonymsFree = TypeFlags 0x04
 --   After substitution:  TypeApp (TypeConstructor SomeAlias) someArg
 --                        -- now a fully-applied synonym that needs expansion!
 -- @
---
--- In PureScript the convention is to expand synonyms before unification, so
--- the substitution /values/ are synonym-free in isolation. But when a
--- 'TUnknown' in function position is substituted with a synonym constructor,
--- the /resulting/ parent @TypeApp@ is a synonym application that must be
--- expanded. We can't detect this from the children's flags alone without
--- inspecting the spine, so we conservatively clear the flag and let
--- 'replaceAllTypeSynonyms' re-scan when asked.
 combineFlags :: TypeFlags -> TypeFlags -> TypeFlags
-combineFlags (TypeFlags a) (TypeFlags b) = TypeFlags ((a .|. b) .&. structuralMask)
+combineFlags (TypeFlags a _) (TypeFlags b _) =
+  TypeFlags ((a .|. b) .&. structuralMask) 0
 
 -- | Mask of flags that propagate structurally from children to parents.
 -- Processing flags (like 'tfSynonymsFree') are excluded — see 'combineFlags'.
 structuralMask :: Word8
 structuralMask = w .|. w' where
-  TypeFlags w  = tfHasWildcards
-  TypeFlags w' = tfHasUnscopedForAlls
+  TypeFlags w  _ = tfHasWildcards
+  TypeFlags w' _ = tfHasUnscopedForAlls
 
 -- | Test whether a specific flag is set.
 hasFlag :: TypeFlags -> TypeFlags -> Bool
-hasFlag (TypeFlags mask) (TypeFlags w) = w .&. mask /= 0
+hasFlag (TypeFlags mask _) (TypeFlags w _) = w .&. mask /= 0
 
--- | Set a flag.
+-- | Set a flag (preserves the existing hash).
 setFlag :: TypeFlags -> TypeFlags -> TypeFlags
-setFlag (TypeFlags f) (TypeFlags w) = TypeFlags (w .|. f)
+setFlag (TypeFlags f _) (TypeFlags w h) = TypeFlags (w .|. f) h
 
 -- | Extract the flags from a Type node.
 typeFlags :: Type a -> TypeFlags
@@ -161,21 +163,152 @@ typeFlags (BinaryNoParensType_ f _ _ _ _) = f
 typeFlags (ParensInType_ f _ _) = f
 
 -- | Mask to extract only structural flags (clearing processing flags).
+-- Preserves the hash.
 maskStructural :: TypeFlags -> TypeFlags
-maskStructural (TypeFlags w) = TypeFlags (w .&. structuralMask)
+maskStructural (TypeFlags w h) = TypeFlags (w .&. structuralMask) h
+
+-- ---------------------------------------------------------------------------
+-- Hash mixing for the per-node structural hash
+-- ---------------------------------------------------------------------------
+
+-- | Per-constructor salt. Distinct so two leaves with the same payload but
+-- different constructors get different hashes (e.g. @TypeVar "x"@ vs
+-- @TypeLevelString "x"@). Values are arbitrary primes.
+ctorSalt_TUnknown, ctorSalt_TypeVar, ctorSalt_TypeLevelString,
+  ctorSalt_TypeLevelInt, ctorSalt_TypeWildcard, ctorSalt_TypeConstructor,
+  ctorSalt_TypeOp, ctorSalt_TypeApp, ctorSalt_KindApp, ctorSalt_ForAll,
+  ctorSalt_ConstrainedType, ctorSalt_Skolem, ctorSalt_REmpty, ctorSalt_RCons,
+  ctorSalt_KindedType, ctorSalt_BinaryNoParensType, ctorSalt_ParensInType
+  :: Int
+ctorSalt_TUnknown            = 1009
+ctorSalt_TypeVar             = 1013
+ctorSalt_TypeLevelString     = 1019
+ctorSalt_TypeLevelInt        = 1021
+ctorSalt_TypeWildcard        = 1031
+ctorSalt_TypeConstructor     = 1033
+ctorSalt_TypeOp              = 1039
+ctorSalt_TypeApp             = 1049
+ctorSalt_KindApp             = 1051
+ctorSalt_ForAll              = 1061
+ctorSalt_ConstrainedType     = 1063
+ctorSalt_Skolem              = 1069
+ctorSalt_REmpty              = 1087
+ctorSalt_RCons               = 1091
+ctorSalt_KindedType          = 1093
+ctorSalt_BinaryNoParensType  = 1097
+ctorSalt_ParensInType        = 1103
+
+-- | Mix two hashes via a multiply-add with the golden-ratio constant.
+-- Same shape as 'Data.Hashable.combine' but inlined and Int-typed.
+mixHash :: Int -> Int -> Int
+mixHash a b = a * 0x9E3779B1 + b
+{-# INLINE mixHash #-}
+
+-- | Build TypeFlags for a leaf node, hashing one payload value.
+leafFlags1 :: Hashable x => Word8 -> Int -> x -> TypeFlags
+leafFlags1 bits salt x = TypeFlags bits (salt `hashWithSalt` x)
+{-# INLINE leafFlags1 #-}
+
+-- | Build TypeFlags for a leaf node, hashing two payload values.
+leafFlags2 :: (Hashable x, Hashable y) => Word8 -> Int -> x -> y -> TypeFlags
+leafFlags2 bits salt x y = TypeFlags bits (salt `hashWithSalt` x `hashWithSalt` y)
+{-# INLINE leafFlags2 #-}
+
+-- | Compute hash of a 'Constraint' from its already-hashed children.
+constraintHash :: Constraint a -> Int
+constraintHash c =
+  ctorSalt_ConstrainedType
+    `hashWithSalt` constraintClass c
+    `hashWithSalt` constraintData c
+    `hashWithSalt` map (tfHash . typeFlags) (constraintKindArgs c)
+    `hashWithSalt` map (tfHash . typeFlags) (constraintArgs c)
+{-# INLINE constraintHash #-}
 
 -- | Compute ForAll flags from its components.
-forAllNodeFlags :: Maybe (Type a) -> Type a -> Maybe SkolemScope -> TypeFlags
-forAllNodeFlags mbK ty Nothing = maybe noFlags (maskStructural . typeFlags) mbK `combineFlags` maskStructural (typeFlags ty) `combineFlags` tfHasUnscopedForAlls
-forAllNodeFlags mbK ty (Just _) = maybe noFlags (maskStructural . typeFlags) mbK `combineFlags` maskStructural (typeFlags ty)
+forAllNodeFlags :: TypeVarVisibility -> Text -> Maybe (Type a) -> Type a -> Maybe SkolemScope -> TypeFlags
+forAllNodeFlags vis ident mbK ty sco =
+    TypeFlags bits hash_
+  where
+    bits =
+      ((maybe 0 (tfBits . typeFlags) mbK .|. tfBits (typeFlags ty)) .&. structuralMask)
+        .|. unscoped
+    unscoped = case sco of Nothing -> tfBits tfHasUnscopedForAlls; _ -> 0
+    hash_ =
+      ctorSalt_ForAll
+        `hashWithSalt` vis
+        `hashWithSalt` ident
+        `hashWithSalt` fmap (tfHash . typeFlags) mbK
+        `hashWithSalt` tfHash (typeFlags ty)
+        `hashWithSalt` sco
+{-# INLINE forAllNodeFlags #-}
 
 -- | Compute ConstrainedType flags from its components.
 constraintNodeFlags :: Constraint a -> Type a -> TypeFlags
-constraintNodeFlags c ty = foldl' combineFlags (maskStructural (typeFlags ty)) (map (maskStructural . typeFlags) (constraintKindArgs c) ++ map (maskStructural . typeFlags) (constraintArgs c))
+constraintNodeFlags c ty =
+    TypeFlags bits hash_
+  where
+    bits =
+      foldl'
+        (\acc f -> acc .|. tfBits f)
+        (tfBits (typeFlags ty))
+        (map typeFlags (constraintKindArgs c) ++ map typeFlags (constraintArgs c))
+        .&. structuralMask
+    hash_ = mixHash (constraintHash c) (tfHash (typeFlags ty))
+{-# INLINE constraintNodeFlags #-}
 
 -- | Compute Skolem flags from its components.
-skolemNodeFlags :: Maybe (Type a) -> TypeFlags
-skolemNodeFlags = maybe noFlags (maskStructural . typeFlags)
+skolemNodeFlags :: Text -> Maybe (Type a) -> Int -> SkolemScope -> TypeFlags
+skolemNodeFlags name mbK i sco =
+    TypeFlags bits hash_
+  where
+    bits = maybe 0 (tfBits . typeFlags) mbK .&. structuralMask
+    hash_ =
+      ctorSalt_Skolem
+        `hashWithSalt` name
+        `hashWithSalt` fmap (tfHash . typeFlags) mbK
+        `hashWithSalt` i
+        `hashWithSalt` sco
+{-# INLINE skolemNodeFlags #-}
+
+-- | Compute flags for a binary inner node (TypeApp, KindApp, KindedType).
+binaryNodeFlags :: Int -> Type a -> Type a -> TypeFlags
+binaryNodeFlags salt t1 t2 =
+    TypeFlags
+      ((tfBits f1 .|. tfBits f2) .&. structuralMask)
+      (mixHash salt (mixHash (tfHash f1) (tfHash f2)))
+  where
+    f1 = typeFlags t1
+    f2 = typeFlags t2
+{-# INLINE binaryNodeFlags #-}
+
+-- | Compute flags for an RCons node.
+rconsNodeFlags :: Label -> Type a -> Type a -> TypeFlags
+rconsNodeFlags l ty rest =
+    TypeFlags
+      ((tfBits f1 .|. tfBits f2) .&. structuralMask)
+      (mixHash (mixHash (ctorSalt_RCons `hashWithSalt` l) (tfHash f1)) (tfHash f2))
+  where
+    f1 = typeFlags ty
+    f2 = typeFlags rest
+{-# INLINE rconsNodeFlags #-}
+
+-- | Compute flags for BinaryNoParensType (3 children).
+ternaryNodeFlags :: Int -> Type a -> Type a -> Type a -> TypeFlags
+ternaryNodeFlags salt t1 t2 t3 =
+    TypeFlags
+      ((tfBits f1 .|. tfBits f2 .|. tfBits f3) .&. structuralMask)
+      (mixHash salt (mixHash (tfHash f1) (mixHash (tfHash f2) (tfHash f3))))
+  where
+    f1 = typeFlags t1
+    f2 = typeFlags t2
+    f3 = typeFlags t3
+{-# INLINE ternaryNodeFlags #-}
+
+-- | Compute flags for a unary inner node (ParensInType).
+unaryNodeFlags :: Int -> Type a -> TypeFlags
+unaryNodeFlags salt t = TypeFlags (tfBits f .&. structuralMask) (mixHash salt (tfHash f))
+  where f = typeFlags t
+{-# INLINE unaryNodeFlags #-}
 
 -- ---------------------------------------------------------------------------
 -- The type of types
@@ -185,23 +318,23 @@ skolemNodeFlags = maybe noFlags (maskStructural . typeFlags)
 -- a 'TypeFlags' field. Use the pattern synonyms (without suffix) which
 -- auto-compute flags on construction and ignore them on matching.
 data Type a
-  = TUnknown_ !TypeFlags a Int
-  | TypeVar_ !TypeFlags a Text
-  | TypeLevelString_ !TypeFlags a PSString
-  | TypeLevelInt_ !TypeFlags a Integer
-  | TypeWildcard_ !TypeFlags a WildcardData
-  | TypeConstructor_ !TypeFlags a (Qualified (ProperName 'TypeName))
-  | TypeOp_ !TypeFlags a (Qualified (OpName 'TypeOpName))
-  | TypeApp_ !TypeFlags a (Type a) (Type a)
-  | KindApp_ !TypeFlags a (Type a) (Type a)
-  | ForAll_ !TypeFlags a TypeVarVisibility Text (Maybe (Type a)) (Type a) (Maybe SkolemScope)
-  | ConstrainedType_ !TypeFlags a (Constraint a) (Type a)
-  | Skolem_ !TypeFlags a Text (Maybe (Type a)) Int SkolemScope
-  | REmpty_ !TypeFlags a
-  | RCons_ !TypeFlags a Label (Type a) (Type a)
-  | KindedType_ !TypeFlags a (Type a) (Type a)
-  | BinaryNoParensType_ !TypeFlags a (Type a) (Type a) (Type a)
-  | ParensInType_ !TypeFlags a (Type a)
+  = TUnknown_ {-# UNPACK #-} !TypeFlags a Int
+  | TypeVar_ {-# UNPACK #-} !TypeFlags a Text
+  | TypeLevelString_ {-# UNPACK #-} !TypeFlags a PSString
+  | TypeLevelInt_ {-# UNPACK #-} !TypeFlags a Integer
+  | TypeWildcard_ {-# UNPACK #-} !TypeFlags a WildcardData
+  | TypeConstructor_ {-# UNPACK #-} !TypeFlags a (Qualified (ProperName 'TypeName))
+  | TypeOp_ {-# UNPACK #-} !TypeFlags a (Qualified (OpName 'TypeOpName))
+  | TypeApp_ {-# UNPACK #-} !TypeFlags a (Type a) (Type a)
+  | KindApp_ {-# UNPACK #-} !TypeFlags a (Type a) (Type a)
+  | ForAll_ {-# UNPACK #-} !TypeFlags a TypeVarVisibility Text (Maybe (Type a)) (Type a) (Maybe SkolemScope)
+  | ConstrainedType_ {-# UNPACK #-} !TypeFlags a (Constraint a) (Type a)
+  | Skolem_ {-# UNPACK #-} !TypeFlags a Text (Maybe (Type a)) Int SkolemScope
+  | REmpty_ {-# UNPACK #-} !TypeFlags a
+  | RCons_ {-# UNPACK #-} !TypeFlags a Label (Type a) (Type a)
+  | KindedType_ {-# UNPACK #-} !TypeFlags a (Type a) (Type a)
+  | BinaryNoParensType_ {-# UNPACK #-} !TypeFlags a (Type a) (Type a) (Type a)
+  | ParensInType_ {-# UNPACK #-} !TypeFlags a (Type a)
   deriving (Show, Generic, Functor, Foldable, Traversable)
 
 instance NFData a => NFData (Type a)
@@ -213,43 +346,43 @@ instance Serialise a => Serialise (Type a)
 
 pattern TUnknown :: a -> Int -> Type a
 pattern TUnknown a i <- TUnknown_ _ a i
-  where TUnknown a i = TUnknown_ noFlags a i
+  where TUnknown a i = TUnknown_ (leafFlags1 0 ctorSalt_TUnknown i) a i
 
 pattern TypeVar :: a -> Text -> Type a
 pattern TypeVar a t <- TypeVar_ _ a t
-  where TypeVar a t = TypeVar_ noFlags a t
+  where TypeVar a t = TypeVar_ (leafFlags1 0 ctorSalt_TypeVar t) a t
 
 pattern TypeLevelString :: a -> PSString -> Type a
 pattern TypeLevelString a s <- TypeLevelString_ _ a s
-  where TypeLevelString a s = TypeLevelString_ noFlags a s
+  where TypeLevelString a s = TypeLevelString_ (leafFlags1 0 ctorSalt_TypeLevelString s) a s
 
 pattern TypeLevelInt :: a -> Integer -> Type a
 pattern TypeLevelInt a n <- TypeLevelInt_ _ a n
-  where TypeLevelInt a n = TypeLevelInt_ noFlags a n
+  where TypeLevelInt a n = TypeLevelInt_ (leafFlags1 0 ctorSalt_TypeLevelInt n) a n
 
 pattern TypeWildcard :: a -> WildcardData -> Type a
 pattern TypeWildcard a w <- TypeWildcard_ _ a w
-  where TypeWildcard a w = TypeWildcard_ tfHasWildcards a w
+  where TypeWildcard a w = TypeWildcard_ (leafFlags1 (tfBits tfHasWildcards) ctorSalt_TypeWildcard w) a w
 
 pattern TypeConstructor :: a -> Qualified (ProperName 'TypeName) -> Type a
 pattern TypeConstructor a q <- TypeConstructor_ _ a q
-  where TypeConstructor a q = TypeConstructor_ noFlags a q
+  where TypeConstructor a q = TypeConstructor_ (leafFlags1 0 ctorSalt_TypeConstructor q) a q
 
 pattern TypeOp :: a -> Qualified (OpName 'TypeOpName) -> Type a
 pattern TypeOp a q <- TypeOp_ _ a q
-  where TypeOp a q = TypeOp_ noFlags a q
+  where TypeOp a q = TypeOp_ (leafFlags1 0 ctorSalt_TypeOp q) a q
 
 pattern TypeApp :: a -> Type a -> Type a -> Type a
 pattern TypeApp a t1 t2 <- TypeApp_ _ a t1 t2
-  where TypeApp a t1 t2 = TypeApp_ (typeFlags t1 `combineFlags` typeFlags t2) a t1 t2
+  where TypeApp a t1 t2 = TypeApp_ (binaryNodeFlags ctorSalt_TypeApp t1 t2) a t1 t2
 
 pattern KindApp :: a -> Type a -> Type a -> Type a
 pattern KindApp a t1 t2 <- KindApp_ _ a t1 t2
-  where KindApp a t1 t2 = KindApp_ (typeFlags t1 `combineFlags` typeFlags t2) a t1 t2
+  where KindApp a t1 t2 = KindApp_ (binaryNodeFlags ctorSalt_KindApp t1 t2) a t1 t2
 
 pattern ForAll :: a -> TypeVarVisibility -> Text -> Maybe (Type a) -> Type a -> Maybe SkolemScope -> Type a
 pattern ForAll a vis ident mbK ty sco <- ForAll_ _ a vis ident mbK ty sco
-  where ForAll a vis ident mbK ty sco = ForAll_ (forAllNodeFlags mbK ty sco) a vis ident mbK ty sco
+  where ForAll a vis ident mbK ty sco = ForAll_ (forAllNodeFlags vis ident mbK ty sco) a vis ident mbK ty sco
 
 pattern ConstrainedType :: a -> Constraint a -> Type a -> Type a
 pattern ConstrainedType a c ty <- ConstrainedType_ _ a c ty
@@ -257,27 +390,27 @@ pattern ConstrainedType a c ty <- ConstrainedType_ _ a c ty
 
 pattern Skolem :: a -> Text -> Maybe (Type a) -> Int -> SkolemScope -> Type a
 pattern Skolem a t mbK i s <- Skolem_ _ a t mbK i s
-  where Skolem a t mbK i s = Skolem_ (skolemNodeFlags mbK) a t mbK i s
+  where Skolem a t mbK i s = Skolem_ (skolemNodeFlags t mbK i s) a t mbK i s
 
 pattern REmpty :: a -> Type a
 pattern REmpty a <- REmpty_ _ a
-  where REmpty a = REmpty_ noFlags a
+  where REmpty a = REmpty_ (TypeFlags 0 ctorSalt_REmpty) a
 
 pattern RCons :: a -> Label -> Type a -> Type a -> Type a
 pattern RCons a l ty rest <- RCons_ _ a l ty rest
-  where RCons a l ty rest = RCons_ (typeFlags ty `combineFlags` typeFlags rest) a l ty rest
+  where RCons a l ty rest = RCons_ (rconsNodeFlags l ty rest) a l ty rest
 
 pattern KindedType :: a -> Type a -> Type a -> Type a
 pattern KindedType a ty k <- KindedType_ _ a ty k
-  where KindedType a ty k = KindedType_ (typeFlags ty `combineFlags` typeFlags k) a ty k
+  where KindedType a ty k = KindedType_ (binaryNodeFlags ctorSalt_KindedType ty k) a ty k
 
 pattern BinaryNoParensType :: a -> Type a -> Type a -> Type a -> Type a
 pattern BinaryNoParensType a t1 t2 t3 <- BinaryNoParensType_ _ a t1 t2 t3
-  where BinaryNoParensType a t1 t2 t3 = BinaryNoParensType_ (typeFlags t1 `combineFlags` typeFlags t2 `combineFlags` typeFlags t3) a t1 t2 t3
+  where BinaryNoParensType a t1 t2 t3 = BinaryNoParensType_ (ternaryNodeFlags ctorSalt_BinaryNoParensType t1 t2 t3) a t1 t2 t3
 
 pattern ParensInType :: a -> Type a -> Type a
 pattern ParensInType a t <- ParensInType_ _ a t
-  where ParensInType a t = ParensInType_ (maskStructural (typeFlags t)) a t
+  where ParensInType a t = ParensInType_ (unaryNodeFlags ctorSalt_ParensInType t) a t
 
 {-# COMPLETE TUnknown, TypeVar, TypeLevelString, TypeLevelInt, TypeWildcard, TypeConstructor, TypeOp, TypeApp, KindApp, ForAll, ConstrainedType, Skolem, REmpty, RCons, KindedType, BinaryNoParensType, ParensInType #-}
 
@@ -961,6 +1094,12 @@ instance Eq (Type a) where
 instance Ord (Type a) where
   compare = compareType
 
+-- | Hashing uses the cached hash on the node — O(1) and ignores the
+-- annotation, matching 'eqType'.
+instance Hashable (Type a) where
+  hash = tfHash . typeFlags
+  hashWithSalt s t = s `hashWithSalt` tfHash (typeFlags t)
+
 eqType :: Type a -> Type b -> Bool
 eqType (TUnknown _ a) (TUnknown _ a') = a == a'
 eqType (TypeVar _ a) (TypeVar _ a') = a == a'
@@ -1037,6 +1176,14 @@ instance Eq (Constraint a) where
 
 instance Ord (Constraint a) where
   compare = compareConstraint
+
+-- | Hashing uses 'constraintHash' — uses children's cached hashes and
+-- ignores the annotation, matching 'eqConstraint'.
+instance Hashable (Constraint a) where
+  hash = constraintHash
+  hashWithSalt s c = s `hashWithSalt` constraintHash c
+
+instance Hashable ConstraintData
 
 eqConstraint :: Constraint a -> Constraint b -> Bool
 eqConstraint (Constraint _ a b c d) (Constraint _ a' b' c' d') = a == a' && and (zipWith eqType b b') && and (zipWith eqType c c') && d == d'

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -143,6 +143,12 @@ setFlag :: TypeFlags -> TypeFlags -> TypeFlags
 setFlag (TypeFlags f _) (TypeFlags w h) = TypeFlags (w .|. f) h
 
 -- | Extract the flags from a Type node.
+--
+-- Note: with the @UNPACK@ pragma on @TypeFlags@ in every 'Type' constructor,
+-- this function reconstructs a 'TypeFlags' value from the unpacked Word8 +
+-- Int fields, which means each call boxes if not inlined. Hot paths that
+-- only need one of the two fields should use 'typeHash' or 'typeBits'
+-- directly to avoid the box.
 typeFlags :: Type a -> TypeFlags
 typeFlags (TUnknown_ f _ _) = f
 typeFlags (TypeVar_ f _ _) = f
@@ -161,6 +167,51 @@ typeFlags (RCons_ f _ _ _ _) = f
 typeFlags (KindedType_ f _ _ _) = f
 typeFlags (BinaryNoParensType_ f _ _ _ _) = f
 typeFlags (ParensInType_ f _ _) = f
+{-# INLINE typeFlags #-}
+
+-- | Direct accessor for a Type's cached hash, avoiding TypeFlags boxing.
+-- Hot paths that read the hash should use this rather than
+-- @tfHash . typeFlags@.
+typeHash :: Type a -> Int
+typeHash (TUnknown_ (TypeFlags _ h) _ _) = h
+typeHash (TypeVar_ (TypeFlags _ h) _ _) = h
+typeHash (TypeLevelString_ (TypeFlags _ h) _ _) = h
+typeHash (TypeLevelInt_ (TypeFlags _ h) _ _) = h
+typeHash (TypeWildcard_ (TypeFlags _ h) _ _) = h
+typeHash (TypeConstructor_ (TypeFlags _ h) _ _) = h
+typeHash (TypeOp_ (TypeFlags _ h) _ _) = h
+typeHash (TypeApp_ (TypeFlags _ h) _ _ _) = h
+typeHash (KindApp_ (TypeFlags _ h) _ _ _) = h
+typeHash (ForAll_ (TypeFlags _ h) _ _ _ _ _ _) = h
+typeHash (ConstrainedType_ (TypeFlags _ h) _ _ _) = h
+typeHash (Skolem_ (TypeFlags _ h) _ _ _ _ _) = h
+typeHash (REmpty_ (TypeFlags _ h) _) = h
+typeHash (RCons_ (TypeFlags _ h) _ _ _ _) = h
+typeHash (KindedType_ (TypeFlags _ h) _ _ _) = h
+typeHash (BinaryNoParensType_ (TypeFlags _ h) _ _ _ _) = h
+typeHash (ParensInType_ (TypeFlags _ h) _ _) = h
+{-# INLINE typeHash #-}
+
+-- | Direct accessor for a Type's bit flags, avoiding TypeFlags boxing.
+typeBits :: Type a -> Word8
+typeBits (TUnknown_ (TypeFlags w _) _ _) = w
+typeBits (TypeVar_ (TypeFlags w _) _ _) = w
+typeBits (TypeLevelString_ (TypeFlags w _) _ _) = w
+typeBits (TypeLevelInt_ (TypeFlags w _) _ _) = w
+typeBits (TypeWildcard_ (TypeFlags w _) _ _) = w
+typeBits (TypeConstructor_ (TypeFlags w _) _ _) = w
+typeBits (TypeOp_ (TypeFlags w _) _ _) = w
+typeBits (TypeApp_ (TypeFlags w _) _ _ _) = w
+typeBits (KindApp_ (TypeFlags w _) _ _ _) = w
+typeBits (ForAll_ (TypeFlags w _) _ _ _ _ _ _) = w
+typeBits (ConstrainedType_ (TypeFlags w _) _ _ _) = w
+typeBits (Skolem_ (TypeFlags w _) _ _ _ _ _) = w
+typeBits (REmpty_ (TypeFlags w _) _) = w
+typeBits (RCons_ (TypeFlags w _) _ _ _ _) = w
+typeBits (KindedType_ (TypeFlags w _) _ _ _) = w
+typeBits (BinaryNoParensType_ (TypeFlags w _) _ _ _ _) = w
+typeBits (ParensInType_ (TypeFlags w _) _ _) = w
+{-# INLINE typeBits #-}
 
 -- | Mask to extract only structural flags (clearing processing flags).
 -- Preserves the hash.
@@ -1097,8 +1148,10 @@ instance Ord (Type a) where
 -- | Hashing uses the cached hash on the node — O(1) and ignores the
 -- annotation, matching 'eqType'.
 instance Hashable (Type a) where
-  hash = tfHash . typeFlags
-  hashWithSalt s t = s `hashWithSalt` tfHash (typeFlags t)
+  hash = typeHash
+  {-# INLINE hash #-}
+  hashWithSalt s t = s `hashWithSalt` typeHash t
+  {-# INLINE hashWithSalt #-}
 
 eqType :: Type a -> Type b -> Bool
 eqType (TUnknown _ a) (TUnknown _ a') = a == a'

--- a/tests/TestAst.hs
+++ b/tests/TestAst.hs
@@ -78,7 +78,7 @@ genTypeAnnotatedWith genTypeAnn genConstraintAnn = genType where
   genQualified ctor = Qualified ByNullSourcePos . ctor <$> genText
 
   genTypeFlags :: Gen TypeFlags
-  genTypeFlags = TypeFlags <$> arbitrary
+  genTypeFlags = TypeFlags <$> arbitrary <*> arbitrary
 
   genSkolemScope :: Gen SkolemScope
   genSkolemScope = SkolemScope <$> arbitrary


### PR DESCRIPTION
## Summary

- **Step 1**: Cache a structural `Int` hash on every `Type` node alongside the existing `TypeFlags`, computed at construction by combining children's cached hashes with a per-constructor salt. Adds `Hashable (Type a)` (O(1) via the cached field) and `Hashable (Constraint a)`.
- **Step 3**: Switch the `unificationCache` in `Unify.hs:121–123` from `Set (Type, Type)` to `HashSet (Type, Type)`. This drops `compareType` from the unification cache hot path entirely.
- Measured **-15.4% on full builds** of pr-admin (median of 4, 47515-49155 ms; tight). Neutral on the three incremental scenarios.
- `Ord Type` is deliberately unchanged — see the rust-interning Phase 2 trap in `LESSONS.md`.

`compareType` was the new top hotspot at 7.7% post-merges (after synonym-opt + skip-redundant-entailment-unify shipped). The unification cache is the largest single source.

## Final results (vs baseline `799e8208`)

| Scenario | Base (s) | Head (s) | Δ | Notes |
|----------|---------:|---------:|---|-------|
| full | 57.0 | 48.2 | **-15.4%** | tight, 47515-49155 ms |
| nochange | 0.6 | 0.6 | -1.9% | tight, 564-594 ms |
| prelude | 4.0 | 4.0 | -0.3% | within noise |
| leaf | 1.6 | 1.6 | -1.1% | very noisy (1550-8576 ms) |

## Two non-obvious implementation details

Both look like minor codegen hints but each is a 2× swing on full builds when missed. Documented in `experiments/LESSONS.md`:

1. **`{-# UNPACK #-}`** on the `!TypeFlags` field of every `Type` constructor. `TypeFlags` went from `newtype` (zero-cost wrapper) to a 2-field record; without UNPACK every Type allocation indirects through an extra boxed object — measured +107% on full. With UNPACK, the regression collapses to ~+1.8%.
2. **`{-# INLINE #-}`** on the `Hashable Type` instance methods. Without it GHC dispatches through the class dictionary at every hash call, allocates thunks, and the supposed HashSet win measures **worse** than Set (+102% on full). With INLINE the dictionary collapses through to a direct field read and the headline win drops out.

A `eqType` hash short-circuit (step 2) was tried and reverted — the hot callers (Entailment.hs:295 guard) compare equal types most of the time, so the hash check just adds work. See LESSONS.md.

## Test plan

- [x] `stack test --fast`: 1340 examples, 0 failures
- [x] All four scenarios on pr-admin: full / nochange / prelude / leaf
- [x] No `Ord Type` changes — iteration order preserved (rust-interning Phase 2 trap avoided)
- [ ] Reviewer eyeballs the new `combineNodeFlags`-style helpers and per-constructor salts in `Types.hs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)