### PR TITLE
unifyTypes: pointer-eq fast-path (-7.5% full build)

### DIFF
--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MagicHash #-}
 -- |
 -- Functions and instances relating to unification
 --
@@ -18,6 +19,7 @@ import Prelude
 
 import Control.Exception (assert)
 import Control.Monad (forM_, unless, void)
+import GHC.Exts (reallyUnsafePtrEquality#, isTrue#)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), gets, modify, state)
 import Control.Monad.Writer.Class (MonadWriter(..))
@@ -113,7 +115,13 @@ unknownsInType t = everythingOnTypes (.) go t []
 
 -- | Unify two types, updating the current substitution
 unifyTypes :: SourceType -> SourceType -> TypeCheckM ()
-unifyTypes t1 t2 = do
+unifyTypes t1 t2
+  -- Pointer-equal arguments are structurally equal, so unifyTypes is a
+  -- no-op: no fresh TUnknowns to solve, no errors. Skip substituteType,
+  -- the hint stack push, and the cache lookup. Sound regardless of the
+  -- ptr-eq result (False just falls through to the existing path).
+  | isTrue# (reallyUnsafePtrEquality# t1 t2) = pure ()
+  | otherwise = do
   sub <- gets checkSubstitution
   withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes'' (substituteType sub t1) (substituteType sub t2)
   where

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -17,7 +17,7 @@ module Language.PureScript.TypeChecker.Unify
 import Prelude
 
 import Control.Exception (assert)
-import Control.Monad (forM_, void, when)
+import Control.Monad (forM_, unless, void)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), gets, modify, state)
 import Control.Monad.Writer.Class (MonadWriter(..))
@@ -119,7 +119,7 @@ unifyTypes t1 t2 = do
   where
   unifyTypes'' t1' t2'= do
     cache <- gets unificationCache
-    when (not (HS.member (t1', t2') cache)) $ do
+    unless (HS.member (t1', t2') cache) $ do
       modify $ \st -> st { unificationCache = HS.insert (t1', t2') cache }
       unifyTypes' t1' t2'
   unifyTypes' (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -301,29 +301,29 @@ modifyFlags f = \case
 -- | Per-constructor salt. Distinct so two leaves with the same payload but
 -- different constructors get different hashes (e.g. @TypeVar "x"@ vs
 -- @TypeLevelString "x"@). Values are arbitrary primes.
-ctorSalt_TUnknown, ctorSalt_TypeVar, ctorSalt_TypeLevelString,
-  ctorSalt_TypeLevelInt, ctorSalt_TypeWildcard, ctorSalt_TypeConstructor,
-  ctorSalt_TypeOp, ctorSalt_TypeApp, ctorSalt_KindApp, ctorSalt_ForAll,
-  ctorSalt_ConstrainedType, ctorSalt_Skolem, ctorSalt_REmpty, ctorSalt_RCons,
-  ctorSalt_KindedType, ctorSalt_BinaryNoParensType, ctorSalt_ParensInType
+ctorSaltTUnknown, ctorSaltTypeVar, ctorSaltTypeLevelString,
+  ctorSaltTypeLevelInt, ctorSaltTypeWildcard, ctorSaltTypeConstructor,
+  ctorSaltTypeOp, ctorSaltTypeApp, ctorSaltKindApp, ctorSaltForAll,
+  ctorSaltConstrainedType, ctorSaltSkolem, ctorSaltREmpty, ctorSaltRCons,
+  ctorSaltKindedType, ctorSaltBinaryNoParensType, ctorSaltParensInType
   :: Int
-ctorSalt_TUnknown            = 1009
-ctorSalt_TypeVar             = 1013
-ctorSalt_TypeLevelString     = 1019
-ctorSalt_TypeLevelInt        = 1021
-ctorSalt_TypeWildcard        = 1031
-ctorSalt_TypeConstructor     = 1033
-ctorSalt_TypeOp              = 1039
-ctorSalt_TypeApp             = 1049
-ctorSalt_KindApp             = 1051
-ctorSalt_ForAll              = 1061
-ctorSalt_ConstrainedType     = 1063
-ctorSalt_Skolem              = 1069
-ctorSalt_REmpty              = 1087
-ctorSalt_RCons               = 1091
-ctorSalt_KindedType          = 1093
-ctorSalt_BinaryNoParensType  = 1097
-ctorSalt_ParensInType        = 1103
+ctorSaltTUnknown            = 1009
+ctorSaltTypeVar             = 1013
+ctorSaltTypeLevelString     = 1019
+ctorSaltTypeLevelInt        = 1021
+ctorSaltTypeWildcard        = 1031
+ctorSaltTypeConstructor     = 1033
+ctorSaltTypeOp              = 1039
+ctorSaltTypeApp             = 1049
+ctorSaltKindApp             = 1051
+ctorSaltForAll              = 1061
+ctorSaltConstrainedType     = 1063
+ctorSaltSkolem              = 1069
+ctorSaltREmpty              = 1087
+ctorSaltRCons               = 1091
+ctorSaltKindedType          = 1093
+ctorSaltBinaryNoParensType  = 1097
+ctorSaltParensInType        = 1103
 
 -- | Build TypeFlags for a leaf node, hashing one payload value.
 leafFlags1 :: Hashable x => Word8 -> Int -> x -> TypeFlags
@@ -333,7 +333,7 @@ leafFlags1 bits salt x = TypeFlags bits (salt `hashWithSalt` x)
 -- | Compute hash of a 'Constraint' from its already-hashed children.
 constraintHash :: Constraint a -> Int
 constraintHash c =
-  ctorSalt_ConstrainedType
+  ctorSaltConstrainedType
     `hashWithSalt` constraintClass c
     `hashWithSalt` constraintData c
     `hashWithSalt` map (tfHash . typeFlags) (constraintKindArgs c)
@@ -350,7 +350,7 @@ forAllNodeFlags vis ident mbK ty sco =
         .|. unscoped
     unscoped = case sco of Nothing -> tfBits tfHasUnscopedForAlls; _ -> 0
     hash_ =
-      ctorSalt_ForAll
+      ctorSaltForAll
         `hashWithSalt` vis
         `hashWithSalt` ident
         `hashWithSalt` fmap (tfHash . typeFlags) mbK
@@ -379,7 +379,7 @@ skolemNodeFlags name mbK i sco =
   where
     bits = maybe 0 (tfBits . typeFlags) mbK .&. structuralMask
     hash_ =
-      ctorSalt_Skolem
+      ctorSaltSkolem
         `hashWithSalt` name
         `hashWithSalt` fmap (tfHash . typeFlags) mbK
         `hashWithSalt` i
@@ -402,7 +402,7 @@ rconsNodeFlags :: Label -> Type a -> Type a -> TypeFlags
 rconsNodeFlags l ty rest =
     TypeFlags
       ((tfBits f1 .|. tfBits f2) .&. structuralMask)
-      (ctorSalt_RCons `hashWithSalt` l `hashWithSalt` tfHash f1 `hashWithSalt` tfHash f2)
+      (ctorSaltRCons `hashWithSalt` l `hashWithSalt` tfHash f1 `hashWithSalt` tfHash f2)
   where
     f1 = typeFlags ty
     f2 = typeFlags rest
@@ -462,39 +462,39 @@ instance Serialise a => Serialise (Type a)
 
 pattern TUnknown :: a -> Int -> Type a
 pattern TUnknown a i <- TUnknown_ _ a i
-  where TUnknown a i = TUnknown_ (leafFlags1 0 ctorSalt_TUnknown i) a i
+  where TUnknown a i = TUnknown_ (leafFlags1 0 ctorSaltTUnknown i) a i
 
 pattern TypeVar :: a -> Text -> Type a
 pattern TypeVar a t <- TypeVar_ _ a t
-  where TypeVar a t = TypeVar_ (leafFlags1 0 ctorSalt_TypeVar t) a t
+  where TypeVar a t = TypeVar_ (leafFlags1 0 ctorSaltTypeVar t) a t
 
 pattern TypeLevelString :: a -> PSString -> Type a
 pattern TypeLevelString a s <- TypeLevelString_ _ a s
-  where TypeLevelString a s = TypeLevelString_ (leafFlags1 0 ctorSalt_TypeLevelString s) a s
+  where TypeLevelString a s = TypeLevelString_ (leafFlags1 0 ctorSaltTypeLevelString s) a s
 
 pattern TypeLevelInt :: a -> Integer -> Type a
 pattern TypeLevelInt a n <- TypeLevelInt_ _ a n
-  where TypeLevelInt a n = TypeLevelInt_ (leafFlags1 0 ctorSalt_TypeLevelInt n) a n
+  where TypeLevelInt a n = TypeLevelInt_ (leafFlags1 0 ctorSaltTypeLevelInt n) a n
 
 pattern TypeWildcard :: a -> WildcardData -> Type a
 pattern TypeWildcard a w <- TypeWildcard_ _ a w
-  where TypeWildcard a w = TypeWildcard_ (leafFlags1 (tfBits tfHasWildcards) ctorSalt_TypeWildcard w) a w
+  where TypeWildcard a w = TypeWildcard_ (leafFlags1 (tfBits tfHasWildcards) ctorSaltTypeWildcard w) a w
 
 pattern TypeConstructor :: a -> Qualified (ProperName 'TypeName) -> Type a
 pattern TypeConstructor a q <- TypeConstructor_ _ a q
-  where TypeConstructor a q = TypeConstructor_ (leafFlags1 0 ctorSalt_TypeConstructor q) a q
+  where TypeConstructor a q = TypeConstructor_ (leafFlags1 0 ctorSaltTypeConstructor q) a q
 
 pattern TypeOp :: a -> Qualified (OpName 'TypeOpName) -> Type a
 pattern TypeOp a q <- TypeOp_ _ a q
-  where TypeOp a q = TypeOp_ (leafFlags1 0 ctorSalt_TypeOp q) a q
+  where TypeOp a q = TypeOp_ (leafFlags1 0 ctorSaltTypeOp q) a q
 
 pattern TypeApp :: a -> Type a -> Type a -> Type a
 pattern TypeApp a t1 t2 <- TypeApp_ _ a t1 t2
-  where TypeApp a t1 t2 = TypeApp_ (binaryNodeFlags ctorSalt_TypeApp t1 t2) a t1 t2
+  where TypeApp a t1 t2 = TypeApp_ (binaryNodeFlags ctorSaltTypeApp t1 t2) a t1 t2
 
 pattern KindApp :: a -> Type a -> Type a -> Type a
 pattern KindApp a t1 t2 <- KindApp_ _ a t1 t2
-  where KindApp a t1 t2 = KindApp_ (binaryNodeFlags ctorSalt_KindApp t1 t2) a t1 t2
+  where KindApp a t1 t2 = KindApp_ (binaryNodeFlags ctorSaltKindApp t1 t2) a t1 t2
 
 pattern ForAll :: a -> TypeVarVisibility -> Text -> Maybe (Type a) -> Type a -> Maybe SkolemScope -> Type a
 pattern ForAll a vis ident mbK ty sco <- ForAll_ _ a vis ident mbK ty sco
@@ -510,7 +510,7 @@ pattern Skolem a t mbK i s <- Skolem_ _ a t mbK i s
 
 pattern REmpty :: a -> Type a
 pattern REmpty a <- REmpty_ _ a
-  where REmpty a = REmpty_ (TypeFlags 0 ctorSalt_REmpty) a
+  where REmpty a = REmpty_ (TypeFlags 0 ctorSaltREmpty) a
 
 pattern RCons :: a -> Label -> Type a -> Type a -> Type a
 pattern RCons a l ty rest <- RCons_ _ a l ty rest
@@ -518,15 +518,15 @@ pattern RCons a l ty rest <- RCons_ _ a l ty rest
 
 pattern KindedType :: a -> Type a -> Type a -> Type a
 pattern KindedType a ty k <- KindedType_ _ a ty k
-  where KindedType a ty k = KindedType_ (binaryNodeFlags ctorSalt_KindedType ty k) a ty k
+  where KindedType a ty k = KindedType_ (binaryNodeFlags ctorSaltKindedType ty k) a ty k
 
 pattern BinaryNoParensType :: a -> Type a -> Type a -> Type a -> Type a
 pattern BinaryNoParensType a t1 t2 t3 <- BinaryNoParensType_ _ a t1 t2 t3
-  where BinaryNoParensType a t1 t2 t3 = BinaryNoParensType_ (ternaryNodeFlags ctorSalt_BinaryNoParensType t1 t2 t3) a t1 t2 t3
+  where BinaryNoParensType a t1 t2 t3 = BinaryNoParensType_ (ternaryNodeFlags ctorSaltBinaryNoParensType t1 t2 t3) a t1 t2 t3
 
 pattern ParensInType :: a -> Type a -> Type a
 pattern ParensInType a t <- ParensInType_ _ a t
-  where ParensInType a t = ParensInType_ (unaryNodeFlags ctorSalt_ParensInType t) a t
+  where ParensInType a t = ParensInType_ (unaryNodeFlags ctorSaltParensInType t) a t
 
 {-# COMPLETE TUnknown, TypeVar, TypeLevelString, TypeLevelInt, TypeWildcard, TypeConstructor, TypeOp, TypeApp, KindApp, ForAll, ConstrainedType, Skolem, REmpty, RCons, KindedType, BinaryNoParensType, ParensInType #-}
 


### PR DESCRIPTION
## Summary

One-line change in `unifyTypes`: when both arguments refer to the same heap object, return immediately — bypassing `substituteType`, the hint-stack push, and the cache lookup. Sound regardless of the result; the fall-through path is unchanged.

```haskell
unifyTypes t1 t2
  | isTrue# (reallyUnsafePtrEquality# t1 t2) = pure ()
  | otherwise = do
  sub <- gets checkSubstitution
  withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes'' (substituteType sub t1) (substituteType sub t2)
  ...
```

## Why

The `unify-callsite-survey` experiment found 75% of unification-cache hits at 3 sites in `Types.hs` are on the trivial pair `(tyFunction, tyFunction)`. Even on a cache hit, every call pays the wrapper overhead: `gets checkSubstitution`, `substituteType` walking closed types, `withErrorMessageHint` pushing/popping the hint stack, and the HashSet lookup. For `tyFunction` propagated from `Environment` (a single shared constant), the two arguments are usually the same heap object — one `reallyUnsafePtrEquality#` short-circuits all of that.

## Results vs `5713e832` baseline (type-hash + lint fix)

| Scenario | Δ |
|---|---:|
| **full** | **-7.5%** (53.1s → 49.1s) |
| nochange | -3.6% |
| prelude | +4.8% |
| leaf | +3.4% |

Tests pass (1340/1340). Binary +4 KB (no inlining shift).

## The trade-off

This is a **partial win**. The full build wins clearly. Cascade rebuild scenarios (prelude touches Prelude → 1342 deps, leaf touches a single module) regress modestly. We tried adding a phase 2 that kept the substituteType/hint-stack short-circuit but still inserted into the cache; the prelude regression was unchanged (+4.7%), so the cause isn't missed cache writes.

A cost-centre profile of the prelude scenario shows `unifyTypes`/`substituteType`/`withErrorMessageHint` all at 0.0% inherited time despite ~188k entries — the regression is below cost-centre granularity, likely a code-gen / branch-prediction / icache effect of the kind LESSONS warns about for any `Unify.hs` modification.

The full-build win is significantly larger than the rebuild-scenario regressions, so net across realistic workload mixes is positive. Full experiment writeup: `experiments/ptr-eq-unify/`.

## Soundness

`reallyUnsafePtrEquality#` returning True implies the two arguments share a heap object → structurally equal → `unifyTypes` is a no-op (no fresh TUnknowns to solve, no errors). Returning False is allowed even on structurally equal inputs; the existing path handles that case unchanged.

## Stacked on

This builds on `type-hash` (which adds `TypeFlags` + HashSet-keyed unification cache; PR pending). The base for this PR is `type-hash`. The change is a few lines that should rebase cleanly onto master once type-hash lands.

## Test plan

- [x] `stack build` — clean compile
- [x] `stack test --fast` — 1340/1340 pass
- [x] All four scenarios benchmarked on pr-admin (median of 4, warm-up discarded)
- [x] Binary size delta verified (+4 KB — no inlining shift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)