### PR TITLE
Replace type-hash + unification cache with leaf fast-path

### DIFF
--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -17,7 +17,7 @@ module Language.PureScript.TypeChecker.Unify
 import Prelude
 
 import Control.Exception (assert)
-import Control.Monad (forM_, void, when)
+import Control.Monad (forM_, void)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), gets, modify, state)
 import Control.Monad.Writer.Class (MonadWriter(..))
@@ -34,7 +34,6 @@ import Language.PureScript.TypeChecker.Kinds (elaborateKind, instantiateKind, un
 import Language.PureScript.TypeChecker.Monad (CheckState(..), Substitution(..), UnkLevel(..), Unknown, getLocalContext, guardWith, lookupUnkName, withErrorMessageHint, TypeCheckM)
 import Language.PureScript.TypeChecker.Skolems (newSkolemConstant, skolemize)
 import Language.PureScript.Types (Constraint(..), pattern REmptyKinded, RowListItem(..), SourceType, Type(..), WildcardData(..), alignRowsWith, everythingOnTypes, everywhereOnTypes, everywhereOnTypesM, getAnnForType, hasFlag, mkForAll, rowFromList, srcTUnknown, tfHasWildcards, typeFlags)
-import Data.Set qualified as S
 
 -- | Generate a fresh type variable with an unknown kind. Avoid this if at all possible.
 freshType :: TypeCheckM SourceType
@@ -112,16 +111,29 @@ unknownsInType t = everythingOnTypes (.) go t []
   go _ = id
 
 -- | Unify two types, updating the current substitution
+--
+-- Pre-substitute leaf fast-path: trivially-equal leaves
+-- (TypeConstructor/TypeVar/TypeLevelString/TypeLevelInt/Skolem
+-- with equal payload) short-circuit before substituteType /
+-- withErrorMessageHint. Per unify-cache-anatomy on post-type-hash
+-- baseline 5713e832: 86% of cache hits were on 1-2-node pairs
+-- of this shape — the pattern is structural to recursive descent
+-- so the same survey shape applies pre-type-hash.
+--
+-- The S.Set unification cache is dropped — relying on the leaf
+-- fast-path to catch the dominant recurrence pattern. Combined
+-- effect tested against 799e8208 (pre-type-hash, S.Set) baseline
+-- and 5713e832 (post-type-hash, HashSet) tip.
 unifyTypes :: SourceType -> SourceType -> TypeCheckM ()
+unifyTypes (TypeConstructor _ c1) (TypeConstructor _ c2) | c1 == c2 = pure ()
+unifyTypes (TypeVar _ v1)         (TypeVar _ v2)         | v1 == v2 = pure ()
+unifyTypes (TypeLevelString _ s1) (TypeLevelString _ s2) | s1 == s2 = pure ()
+unifyTypes (TypeLevelInt _ n1)    (TypeLevelInt _ n2)    | n1 == n2 = pure ()
+unifyTypes (Skolem _ _ _ s1 _)    (Skolem _ _ _ s2 _)    | s1 == s2 = pure ()
 unifyTypes t1 t2 = do
   sub <- gets checkSubstitution
-  withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes'' (substituteType sub t1) (substituteType sub t2)
+  withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes' (substituteType sub t1) (substituteType sub t2)
   where
-  unifyTypes'' t1' t2'= do
-    cache <- gets unificationCache
-    when (S.notMember (t1', t2') cache) $ do
-      modify $ \st -> st { unificationCache = S.insert (t1', t2') cache }
-      unifyTypes' t1' t2'
   unifyTypes' (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()
   unifyTypes' (TUnknown _ u) t = solveType u t
   unifyTypes' t (TUnknown _ u) = solveType u t

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -110,20 +110,11 @@ unknownsInType t = everythingOnTypes (.) go t []
   go (TUnknown ann u) = ((ann, u) :)
   go _ = id
 
--- | Unify two types, updating the current substitution
+-- | Unify two types, updating the current substitution.
 --
--- Pre-substitute leaf fast-path: trivially-equal leaves
--- (TypeConstructor/TypeVar/TypeLevelString/TypeLevelInt/Skolem
--- with equal payload) short-circuit before substituteType /
--- withErrorMessageHint. Per unify-cache-anatomy on post-type-hash
--- baseline 5713e832: 86% of cache hits were on 1-2-node pairs
--- of this shape — the pattern is structural to recursive descent
--- so the same survey shape applies pre-type-hash.
---
--- The S.Set unification cache is dropped — relying on the leaf
--- fast-path to catch the dominant recurrence pattern. Combined
--- effect tested against 799e8208 (pre-type-hash, S.Set) baseline
--- and 5713e832 (post-type-hash, HashSet) tip.
+-- Equal-leaf cases short-circuit before substituteType, which
+-- is a no-op on these constructors, and the error-hint bracket,
+-- which can't fire on equal leaves.
 unifyTypes :: SourceType -> SourceType -> TypeCheckM ()
 unifyTypes (TypeConstructor _ c1) (TypeConstructor _ c2) | c1 == c2 = pure ()
 unifyTypes (TypeVar _ v1)         (TypeVar _ v2)         | v1 == v2 = pure ()


### PR DESCRIPTION
## Summary

Adds a 5-line leaf fast-path to `unifyTypes` that catches trivially-equal leaves (TypeConstructor / TypeVar / TypeLevelString / TypeLevelInt / Skolem self-equality) before `substituteType` and the error-hint bracket. Also drops the per-module `S.Set (Type, Type)` `unificationCache` — the leaf fast-path catches its dominant hits upstream cheaply enough that the cache is no longer needed.

## Performance

Measured on pr-admin (1758 modules), median of 6 clean runs vs `restaumatic`:

| Scenario | Δ           |
| -------- | ----------: |
| full     | **-18.6%**  |
| nochange | +3.9%       |
| prelude  | -0.9%       |
| leaf     | -0.1%       |

For reference, the pending `type-hash` PR (alternative direction — adds per-node hash + HashSet to make the cache cheap) shipped at -15.4% on full. This PR comes in slightly stronger on full while removing rather than adding machinery.

## What changes

**Removed:**
- `S.Set (Type, Type)` `unificationCache` lookup wrapper in `unifyTypes`
- Imports `Data.Set qualified as S`, `Control.Monad.when`

**Added:** 5 top-level pattern clauses on `unifyTypes`:

```haskell
unifyTypes (TypeConstructor _ c1) (TypeConstructor _ c2) | c1 == c2 = pure ()
unifyTypes (TypeVar _ v1)         (TypeVar _ v2)         | v1 == v2 = pure ()
unifyTypes (TypeLevelString _ s1) (TypeLevelString _ s2) | s1 == s2 = pure ()
unifyTypes (TypeLevelInt _ n1)    (TypeLevelInt _ n2)    | n1 == n2 = pure ()
unifyTypes (Skolem _ _ _ s1 _)    (Skolem _ _ _ s2 _)    | s1 == s2 = pure ()
```

The same equality cases also exist in `unifyTypes'` lower down (e.g. `unifyTypes' (TypeVar _ v1) (TypeVar _ v2) | v1 == v2`); the difference is that those run *after* `substituteType` and inside the `withErrorMessageHint` bracket. Lifting them above the wrapper saves both for the dominant case.

## Soundness

The fast-path skips two things relative to the existing path: `substituteType sub` and the `withErrorMessageHint` bracket. Both must be no-ops on the equal-leaf case for the rewrite to be observationally identical.

`substituteType sub = everywhereOnTypes go` only rewrites `TUnknown` nodes (`Unify.hs:84-91`). For each fast-path constructor:

| Constructor | Carries `TUnknown` children? | Existing `unifyTypes'` clause |
|---|---|---|
| `TypeConstructor _ c` | No (leaf with `Qualified ProperName`) | `Unify.hs:146-147` → returns `()` when `c1 == c2` |
| `TypeVar _ v` | No (leaf with `Text`) | `Unify.hs:145` → returns `()` when `v1 == v2` |
| `TypeLevelString _ s` | No (leaf with `PSString`) | `Unify.hs:148` → returns `()` |
| `TypeLevelInt _ n` | No (leaf with `Integer`) | `Unify.hs:149` → returns `()` |
| `Skolem _ _ mbK i _` | Yes — `mbK :: Maybe (Type a)` | `Unify.hs:156` → returns `()` when `i1 == i2`, **also ignoring the kind** |

For 1–4: `substituteType sub leaf = leaf` definitionally (no `TUnknown` to rewrite), and the existing clause returns `()` for equal leaves → identical behaviour.

For Skolem (the one with subtlety): the existing `unifyTypes'` clause already short-circuits on the Int alone, ignoring `mbK`, `name`, and `scope`. That's safe by typechecker invariant — `newSkolemConstant` hands out a unique fresh Int per skolem, so the Int *is* the identity. `substituteType` could rewrite `TUnknown`s inside `mbK`, but it can't rewrite the Int (which is what we match on), so the equality test gives the same answer pre- and post-substitution. The fast-path matches the existing clause's semantics, just earlier.

`withErrorMessageHint` (`Monad.hs:188-194`) pushes a hint, runs the action, restores the original `checkHints`. On success it's a pure roundtrip (zero observable state change). It only matters when the action throws — and `unifyTypes' leaf leaf` for equal leaves cannot throw. So skipping the bracket is observationally identical.

The fast-path does not check kind-equality of skolems with the same Int. Neither does the existing path — both treat the Int as identity. Not a regression.

## Why this works

The cache's hits are dominated by trivial leaf-equality recurrences — 86% are 1-2-node pairs like `(TypeConstructor c, TypeConstructor c)`, surfaced from recursive descent through `TypeApp` / `RCons` / `KindApp` / `ConstrainedType`. The leaf fast-path catches those upstream of the cache, eliminating its bookkeeping for the dominant case. The remaining 14% of hits don't earn enough wall-clock time to justify the cache.

Survey data from [`experiments/unify-cache-anatomy`](experiments/unify-cache-anatomy/results.md); cross-experiment narrative in [`experiments/LESSONS.md`](experiments/LESSONS.md) under "type-hash's value is contingent on having a cache".

## Follow-up

Mechanical cleanup, not in this PR: drop the `unificationCache` field from `CheckState` (currently unread/unwritten).

## Test plan

- [x] `stack test --fast` — 1340/1340 tests pass
- [x] pr-admin compile (1758 modules, 4 scenarios × 6 clean runs each)